### PR TITLE
actions: Fix upload-release; remove action-rs actions

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -8,21 +8,17 @@ on:
 env:
   CARGO_TERM_COLOR: always
   CARGO_REGISTRIES_AGRIAN_REGISTRY_INDEX: ${{ secrets.AGRIAN_CRATES_REGISTRY }}
-  CARGO_NET_GIT_FETCH_WITH_CLI: true
 
 jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
     steps:
+      - name: Setup SSH
+        uses: webfactory/ssh-agent@ee29fafb6aa450493bac9136b346e51ea60a8b5e
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
       - uses: actions/checkout@v2
-        with:
-          ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
       - uses: actions/cache@v2
         with:
           path: |

--- a/.github/workflows/upload-release.yml
+++ b/.github/workflows/upload-release.yml
@@ -26,6 +26,8 @@ jobs:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
       - name: Checkout code
         uses: actions/checkout@v2
+        with:
+          ref: ${{ env.TAG }}
       - uses: actions/cache@v2
         with:
           path: |
@@ -36,8 +38,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml') }}
             ${{ runner.os }}-cargo
-      - name: Build project
-        run: cargo build --release --frozen
+      - name: Build wise_units-ffi
+        run: cargo build --release --package wise_units-ffi
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
@@ -56,5 +58,5 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
           asset_path: ./target/release/libwise_units_ffi.so
-          asset_name: libwise_units_ffi-linux-amd64
+          asset_name: libwise_units_ffi-linux-amd64.so
           asset_content_type: application/octet-stream


### PR DESCRIPTION
The only way I could see to test the upload-release action out was to merge it to develop; I did that in a previous branch, so this just fixes it to make sure it works. Right now I'm only releasing `wise_units-ffi` in linux-amd64 (for @agrian-joel)--do we need/want any others?

https://github.com/agrian-inc/wise_units/releases/tag/0.15.0