### PR TITLE
Bring back dropped symbols

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,11 @@ members = [
 git = "ssh://git@bitbucket.org/agrian/ffi_common.git"
 branch = "develop"
 
+[patch."agrian-registry".ffi_consumer]
+# path = "../ffi_common/ffi_consumer"
+git = "ssh://git@bitbucket.org/agrian/ffi_common.git"
+branch = "develop"
+
 [patch."agrian-registry".ffi_derive]
 # path = "../ffi_common/ffi_derive"
 git = "ssh://git@bitbucket.org/agrian/ffi_common.git"


### PR DESCRIPTION
unit_composition
unit_composition_buf
unit_expression_buf

were dropped when `[patch."agrian-registry".ffi_consumer]` was removed
