### PR TITLE
Use macOS 10.15 for iOS unit tests.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @agrian-inc/rust-devs

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -37,7 +37,7 @@ jobs:
 
   check-ios:
     name: Test (x86_64-apple-ios)
-    runs-on: macos-latest
+    runs-on: macos-10.15
     env:
       DYLD_ROOT_PATH: '/Applications/Xcode.app/Contents/Developer/Applications/Simulator.app'
     steps:


### PR DESCRIPTION
GitHub is updating `macos-latest` to use macOS 11, which breaks linking
when building for iOS.
