### PR TITLE
DEV-19946 

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -11,6 +11,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Implemented `AsRef<Self>` for `Measurement` and `Unit`. Allows for downstream wrapper types to
   implement other functionality for all types via the `AsRef` implementation.
+- Implemented `TryFrom<&str> for Unit` (which just calls `from_str()`) to allow for downstream
+  wrapper implementations around `Unit`.
 - New `const` `Composition` methods: `new_dimless()`, `new_any()`.
 - New `composition` `const`s for common dimensional compositions.
 

--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -19,6 +19,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Exported `parser::composition` from the crate root.
+- Changed `AsFraction` trait definition to allow for non-optional `Numerator` and `Denominator`.
 - Updated to Rust edition `2021`.
 
 ## [0.21.1] - 2021-11-19

--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -7,6 +7,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [unreleased]
 
+### Added
+
+- Implemented `AsRef<Self>` for `Measurement` and `Unit`. Allows for downstream wrapper types to
+  implement other functionality for all types via the `AsRef` implementation.
+
 ### Changed
 
 - Updated to Rust edition `2021`.

--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -19,6 +19,9 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Exported `parser::composition` from the crate root.
+- `Measurement::try_new()` now takes `unit: U`, `where Unit: TryFrom<U, crate::Error>`. This still
+  allows for passing in a unit expression as a `&str`, but also allows for any other
+  implementations of type conversions to `Unit`.
 - Changed `AsFraction` trait definition to allow for non-optional `Numerator` and `Denominator`.
 - Updated to Rust edition `2021`.
 

--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -12,6 +12,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Implemented `AsRef<Self>` for `Measurement` and `Unit`. Allows for downstream wrapper types to
   implement other functionality for all types via the `AsRef` implementation.
 - New `const` `Composition` methods: `new_dimless()`, `new_any()`.
+- New `composition` `const`s for common dimensional compositions.
 
 ### Changed
 

--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -16,6 +16,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Exported `parser::composition` from the crate root.
 - Updated to Rust edition `2021`.
 
 ## [0.21.1] - 2021-11-19

--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -11,6 +11,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - Implemented `AsRef<Self>` for `Measurement` and `Unit`. Allows for downstream wrapper types to
   implement other functionality for all types via the `AsRef` implementation.
+- New `const` `Composition` methods: `new_dimless()`, `new_any()`.
 
 ### Changed
 

--- a/api/src/as_fraction.rs
+++ b/api/src/as_fraction.rs
@@ -5,10 +5,10 @@ pub trait AsFraction {
     type Denominator;
     type Numerator;
 
-    fn as_fraction(&self) -> (Option<Self::Numerator>, Option<Self::Denominator>) {
+    fn as_fraction(&self) -> (Self::Numerator, Self::Denominator) {
         (self.numerator(), self.denominator())
     }
 
-    fn numerator(&self) -> Option<Self::Numerator>;
-    fn denominator(&self) -> Option<Self::Denominator>;
+    fn numerator(&self) -> Self::Numerator;
+    fn denominator(&self) -> Self::Denominator;
 }

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -42,8 +42,8 @@ pub use crate::{
     is_compatible_with::IsCompatibleWith,
     measurement::Measurement,
     parser::{
-        Atom, Classification, Composable, Composition, Dimension, Prefix, Property, Term,
-        UcumSymbol,
+        composition, Atom, Classification, Composable, Composition, Dimension, Prefix, Property,
+        Term, UcumSymbol,
     },
     ucum_unit::UcumUnit,
     unit::Unit,

--- a/api/src/measurement.rs
+++ b/api/src/measurement.rs
@@ -42,11 +42,11 @@ pub struct Measurement {
 }
 
 impl Measurement {
-    /// Creates a new `Measurement` by parsing `expression` into a `Unit`.
+    /// Creates a new `Measurement` by converting `value` to an `f64` and `unit` to a `Unit`.
     ///
     /// # Errors
     ///
-    /// Returns an `Error` if `expression` isn't one that represents a valid `Unit`.
+    /// Returns an `Error` if `unit` can't be converted to a `Unit`.
     ///
     #[inline]
     pub fn try_new<V, U, E>(value: V, unit: U) -> Result<Self, E>

--- a/api/src/measurement.rs
+++ b/api/src/measurement.rs
@@ -107,6 +107,12 @@ impl Measurement {
     }
 }
 
+impl AsRef<Self> for Measurement {
+    fn as_ref(&self) -> &Self {
+        self
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{

--- a/api/src/parser.rs
+++ b/api/src/parser.rs
@@ -11,6 +11,7 @@
 )]
 pub mod atom;
 pub mod classification;
+pub mod composition;
 #[allow(clippy::non_ascii_literal)]
 pub mod property;
 
@@ -20,7 +21,6 @@ mod annotation_composition;
 #[cfg(test)]
 mod atom_test;
 mod composable;
-mod composition;
 mod definition;
 mod dimension;
 mod error;

--- a/api/src/parser/composition.rs
+++ b/api/src/parser/composition.rs
@@ -82,6 +82,19 @@ impl Composition {
     }
 
     #[must_use]
+    pub const fn new_dimless() -> Self {
+        Self {
+            electric_charge: None,
+            length: None,
+            luminous_intensity: None,
+            mass: None,
+            plane_angle: None,
+            temperature: None,
+            time: None,
+        }
+    }
+
+    #[must_use]
     pub const fn new_electric_charge(exponent: i32) -> Self {
         Self {
             electric_charge: Some(exponent),
@@ -169,6 +182,27 @@ impl Composition {
             plane_angle: None,
             temperature: None,
             time: Some(exponent),
+        }
+    }
+
+    #[must_use]
+    pub const fn new_any(
+        electric_charge: Option<i32>,
+        length: Option<i32>,
+        luminous_intensity: Option<i32>,
+        mass: Option<i32>,
+        plane_angle: Option<i32>,
+        temperature: Option<i32>,
+        time: Option<i32>,
+    ) -> Self {
+        Self {
+            electric_charge,
+            length,
+            luminous_intensity,
+            mass,
+            plane_angle,
+            temperature,
+            time,
         }
     }
 

--- a/api/src/parser/composition.rs
+++ b/api/src/parser/composition.rs
@@ -3,6 +3,59 @@ use std::{fmt, ops::Mul};
 
 type Exponent = i32;
 
+pub const DIMLESS: Composition = Composition::new_dimless();
+
+pub const ELECTRIC_CHARGE: Composition = Composition::new_electric_charge(1);
+
+pub const LENGTH: Composition = Composition::new_length(1);
+pub const AREA: Composition = Composition::new_length(2);
+pub const VOLUME: Composition = Composition::new_length(3);
+
+pub const MASS: Composition = Composition::new_mass(1);
+pub const LUMINOUS_INTENSITY: Composition = Composition::new_luminous_intensity(1);
+pub const TEMPERATURE: Composition = Composition::new_temperature(1);
+pub const TIME: Composition = Composition::new_time(1);
+
+// L.T-1
+pub const VELOCITY: Composition =
+    Composition::new_any(None, Some(1), None, None, None, None, Some(-1));
+
+// L.T-2
+pub const ACCELERATION: Composition =
+    Composition::new_any(None, Some(1), None, None, None, None, Some(-2));
+
+// M.L-3
+pub const DENSITY: Composition =
+    Composition::new_any(None, Some(-3), None, Some(1), None, None, None);
+
+// M.L.T-2
+pub const FORCE: Composition =
+    Composition::new_any(None, Some(1), None, Some(1), None, None, Some(-2));
+
+// M.L-1.T-2
+pub const PRESSURE: Composition =
+    Composition::new_any(None, Some(-1), None, Some(1), None, None, Some(-2));
+
+// M.L2.T-2
+pub const ENEGERY: Composition =
+    Composition::new_any(None, Some(2), None, Some(1), None, None, Some(-2));
+
+// M.L2.T-3
+pub const POWER: Composition =
+    Composition::new_any(None, Some(2), None, Some(1), None, None, Some(-3));
+
+// M.L-1.T-1
+pub const DYNAMIC_VISCOSITY: Composition =
+    Composition::new_any(None, Some(-1), None, Some(1), None, None, Some(-1));
+
+// L2.T-1
+pub const KINEMATIC_VISCOSITY: Composition =
+    Composition::new_any(None, Some(2), None, None, None, None, Some(-1));
+
+// L2.Q-1.T-2
+pub const SPECIFIC_HEAT: Composition =
+    Composition::new_any(None, Some(2), None, None, None, Some(-1), Some(-2));
+
 /// A `Composition` represents the makeup of a `Unit`'s dimensions; only
 /// dimensions and each `Unit`s `Term`'s exponent. For example, "m" would
 /// effectively have the composition string of "L"; "m2" would be "L2"; "1/m2"

--- a/api/src/unit.rs
+++ b/api/src/unit.rs
@@ -20,10 +20,12 @@ mod ucum_unit;
 pub mod custom_ffi;
 #[cfg(feature = "serde")]
 mod serde;
+
+use crate::{parser::Term, Error};
+use std::str::FromStr;
+
 #[cfg(feature = "cffi")]
 use ffi_common::derive::FFI;
-
-use crate::parser::Term;
 
 #[cfg_attr(
     feature = "cffi",
@@ -147,6 +149,14 @@ impl Unit {
 impl AsRef<Self> for Unit {
     fn as_ref(&self) -> &Self {
         self
+    }
+}
+
+impl<'a> TryFrom<&'a str> for Unit {
+    type Error = Error;
+
+    fn try_from(value: &'a str) -> Result<Self, Self::Error> {
+        Self::from_str(value)
     }
 }
 

--- a/api/src/unit.rs
+++ b/api/src/unit.rs
@@ -144,6 +144,12 @@ impl Unit {
     }
 }
 
+impl AsRef<Self> for Unit {
+    fn as_ref(&self) -> &Self {
+        self
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/api/src/unit/as_fraction.rs
+++ b/api/src/unit/as_fraction.rs
@@ -1,11 +1,11 @@
 use crate::{as_fraction::AsFraction, invert::ToInverse, parser::Term, unit::Unit};
 
 impl AsFraction for Unit {
-    type Numerator = Self;
-    type Denominator = Self;
+    type Numerator = Option<Self>;
+    type Denominator = Option<Self>;
 
     #[inline]
-    fn numerator(&self) -> Option<Self::Numerator> {
+    fn numerator(&self) -> Self::Numerator {
         let positive_terms: Vec<Term> = self
             .terms
             .iter()
@@ -21,7 +21,7 @@ impl AsFraction for Unit {
     }
 
     #[inline]
-    fn denominator(&self) -> Option<Self::Denominator> {
+    fn denominator(&self) -> Self::Denominator {
         let negative_terms: Vec<Term> = self
             .terms
             .iter()

--- a/atom_generator/src/toml_structs/toml_atom.rs
+++ b/atom_generator/src/toml_structs/toml_atom.rs
@@ -63,17 +63,17 @@ fn sanitize_type_name_segment(mut string: String) -> String {
 #[allow(clippy::non_ascii_literal)]
 fn remove_non_latin_chars(string: &str) -> String {
     string
-        .replace("è", "e")
-        .replace("é", "e")
-        .replace("Å", "A")
-        .replace("ö", "o")
+        .replace('è', "e")
+        .replace('é', "e")
+        .replace('Å', "A")
+        .replace('ö', "o")
 }
 
 fn remove_non_letter_chars(string: &str) -> String {
     string
-        .replace("'", "")
-        .replace("*", " Star")
-        .replace("^", " Caret")
+        .replace('\'', "")
+        .replace('*', " Star")
+        .replace('^', " Caret")
 }
 
 fn finally(name: &str, primary_code: &str) -> String {


### PR DESCRIPTION
Mainly came here to impl the `AsRef<Measurement>` trait to `Measurement` to make it possible to implement traits against `T where T: AsRef<Measurement>`, but ended up doing a few other things as well. 